### PR TITLE
Add Thunder Client test specification for login endpoint

### DIFF
--- a/login-test.json
+++ b/login-test.json
@@ -1,0 +1,24 @@
+{
+  "name": "Login Endpoint Test",
+  "request": {
+    "method": "POST",
+    "url": "http://localhost:3000/login",
+    "body": {
+      "mode": "raw",
+      "raw": "{\n  \"username\": \"testuser\",\n  \"password\": \"testpass\"\n}"
+    },
+    "headers": [
+      {
+        "key": "Content-Type",
+        "value": "application/json"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "mode": "raw",
+      "raw": "{\n  \"accessToken\": \"<JWT_TOKEN_HERE>\"\n}"
+    }
+  }
+}


### PR DESCRIPTION
Related to #2

Adds a new file `login-test.json` to specify a test for the `/login` endpoint for Thunder Client importation. This file includes:
- A POST request configuration to the `/login` endpoint with example `username` and `password` in the request body.
- The expected response format, including a JWT token, to validate the success of the login operation.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/professorbossini/pessoal_teste_github_workspace_login_jwt/issues/2?shareId=ae518d28-2db3-440d-964e-f1549b884cc0).