### PR TITLE
Expand Thunder Client request collection

### DIFF
--- a/login-test.json
+++ b/login-test.json
@@ -1,24 +1,51 @@
 {
-  "name": "Login Endpoint Test",
-  "request": {
-    "method": "POST",
-    "url": "http://localhost:3000/login",
-    "body": {
-      "mode": "raw",
-      "raw": "{\n  \"username\": \"testuser\",\n  \"password\": \"testpass\"\n}"
-    },
-    "headers": [
+  "collection": {
+    "name": "Login Tests",
+    "requests": [
       {
-        "key": "Content-Type",
-        "value": "application/json"
+        "name": "Login Endpoint Test",
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:3000/login",
+          "body": {
+            "mode": "raw",
+            "raw": "{\n  \"username\": \"testuser\",\n  \"password\": \"testpass\"\n}"
+          },
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "response": {
+          "status": 200,
+          "body": {
+            "mode": "raw",
+            "raw": "{\n  \"accessToken\": \"<JWT_TOKEN_HERE>\"\n}"
+          }
+        }
+      },
+      {
+        "name": "Token Validation Test",
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3000/validate-token",
+          "headers": [
+            {
+              "key": "Authorization",
+              "value": "Bearer <JWT_TOKEN_HERE>"
+            }
+          ]
+        },
+        "response": {
+          "status": 200,
+          "body": {
+            "mode": "raw",
+            "raw": "{\n  \"valid\": true\n}"
+          }
+        }
       }
     ]
-  },
-  "response": {
-    "status": 200,
-    "body": {
-      "mode": "raw",
-      "raw": "{\n  \"accessToken\": \"<JWT_TOKEN_HERE>\"\n}"
-    }
   }
 }


### PR DESCRIPTION
Related to #4

Updates the `login-test.json` file to include a collection of request definitions for testing login and token validation.

- Transforms the existing login request into part of a new collection named "Login Tests".
- Adds a new request definition for a "Token Validation Test" within the "Login Tests" collection, including method, URL, and headers for a GET request to `/validate-token`.
- Maintains the structure for request and response details, including method, URL, body, and headers for both the login and token validation requests.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/professorbossini/pessoal_teste_github_workspace_login_jwt/issues/4?shareId=73591b5e-bcb8-4d18-9240-294355059767).